### PR TITLE
Add "Accept" header

### DIFF
--- a/server.py
+++ b/server.py
@@ -57,7 +57,7 @@ class PersonalityInsightsService:
             raise Exception("No Personality Insights service is bound to this app")
         response = requests.post(self.url + "/v2/profile",
                           auth=(self.username, self.password),
-                          headers = {"content-type": "text/plain"},
+                          headers = {"content-type": "text/plain" , "Accept": "application/json"},
                           data=text
                           )
         try:


### PR DESCRIPTION
Currently, the API is misbehaving. It will default to sending back a non-JSON response (CSV) because the input is not sent JSON. The v2 API doc states the default should be JSON. Until that is resolved, I submit this workaround